### PR TITLE
Modify shuffleArray() to provide uniform sampling. (Related to #10)

### DIFF
--- a/dist-node/index.js
+++ b/dist-node/index.js
@@ -347,7 +347,7 @@ function randomInt(max) {
 function shuffleArray(original) {
   // Swap each element with another randomly selected one.
   for (var i = original.length - 1; i > 0; i--) {
-    var j = Math.floor(Math.random() * (i + 1));
+    var j = randomInt(i);
     var contents = original[i];
     original[i] = original[j];
     original[j] = contents;

--- a/dist-node/index.js
+++ b/dist-node/index.js
@@ -346,13 +346,8 @@ function randomInt(max) {
 
 function shuffleArray(original) {
   // Swap each element with another randomly selected one.
-  for (var i = 0; i < original.length; i++) {
-    var j = i;
-
-    while (j === i) {
-      j = Math.floor(Math.random() * original.length);
-    }
-
+  for (var i = original.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
     var contents = original[i];
     original[i] = original[j];
     original[j] = contents;

--- a/dist-src/index.js
+++ b/dist-src/index.js
@@ -365,13 +365,8 @@ function randomInt(max) {
 
 function shuffleArray(original) {
   // Swap each element with another randomly selected one.
-  for (var i = 0; i < original.length; i++) {
-    var j = i;
-
-    while (j === i) {
-      j = Math.floor(Math.random() * original.length);
-    }
-
+  for (var i = original.length - 1; i > 0; i--) {
+    var j = randomInt(i);
     var contents = original[i];
     original[i] = original[j];
     original[j] = contents;

--- a/dist-web/index.js
+++ b/dist-web/index.js
@@ -344,13 +344,8 @@ function randomInt(max) {
 
 function shuffleArray(original) {
   // Swap each element with another randomly selected one.
-  for (var i = 0; i < original.length; i++) {
-    var j = i;
-
-    while (j === i) {
-      j = Math.floor(Math.random() * original.length);
-    }
-
+  for (var i = original.length - 1; i > 0; i--) {
+    var j = randomInt(i);
     var contents = original[i];
     original[i] = original[j];
     original[j] = contents;


### PR DESCRIPTION
The original shuffleArray function was not uniform. This can be proved by noting that there are n-1 choices at each of the n positions of the array, but (n-1)^n is not divisible by n! (n factorial). The new proposed function should produce every permutation with equal probability.